### PR TITLE
Prefix log messages with timestamp

### DIFF
--- a/cmd/yggmail/main.go
+++ b/cmd/yggmail/main.go
@@ -48,7 +48,7 @@ func (i *peerAddrList) Set(value string) error {
 func main() {
 	rawlog := log.New(color.Output, "", 0)
 	green := color.New(color.FgGreen).SprintfFunc()
-	log := log.New(rawlog.Writer(), fmt.Sprintf("[  %s  ] ", green("Yggmail")), 0)
+	log := log.New(rawlog.Writer(), fmt.Sprintf("[  %s  ] ", green("Yggmail")), log.LstdFlags | log.Lmsgprefix)
 
 	var peerAddrs peerAddrList
 	database := flag.String("database", "yggmail.db", "SQLite database file")


### PR DESCRIPTION
Prefixes log messages with a timestamp using the default format from go log package YYYY/MM/DD hh:mm:ss (local time), e.g.:

```
2021/10/19 18:43:59 [  Yggmail  ] Listening for IMAP on: localhost:1143
```