### PR TITLE
The mcastregexp parameter has been added

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The following command line switches are supported by the `yggmail` binary:
 
 * `-peer=tls://...` or `-peer=tcp://...` — connect to a specific Yggdrasil node, like one of the [Public Peers](https://publicpeers.neilalexander.dev/);
 * `-multicast` - enable multicast peer discovery for Yggdrasil nodes on your LAN
+* `-mcastregexp=".*"` - regexp used in muticast peer discovery for interface name selection.
 * `-database=/path/to/yggmail.db` — use a specific database file;
 * `-smtp=listenaddr:port` — listen for SMTP on a specific address/port
 * `-imap=listenaddr:port` — listen for IMAP on a specific address/port;

--- a/cmd/yggmail/main.go
+++ b/cmd/yggmail/main.go
@@ -55,6 +55,7 @@ func main() {
 	smtpaddr := flag.String("smtp", "localhost:1025", "SMTP listen address")
 	imapaddr := flag.String("imap", "localhost:1143", "IMAP listen address")
 	multicast := flag.Bool("multicast", false, "Connect to Yggdrasil peers on your LAN")
+        mcastregexp := flag.String("mcastregexp", ".*", "Regexp for multicast")
 	password := flag.Bool("password", false, "Set a new IMAP/SMTP password")
 	flag.Var(&peerAddrs, "peer", "Connect to a specific Yggdrasil static peer (this option can be given more than once)")
 	flag.Parse()
@@ -135,6 +136,7 @@ func main() {
 	case (multicast == nil || !*multicast) && len(peerAddrs) == 0:
 		log.Printf("You must specify either -peer, -multicast or both!")
 		os.Exit(0)
+
 	}
 
 	cfg := &config.Config{
@@ -142,7 +144,7 @@ func main() {
 		PrivateKey: sk,
 	}
 
-	transport, err := transport.NewYggdrasilTransport(rawlog, sk, pk, peerAddrs, *multicast)
+	transport, err := transport.NewYggdrasilTransport(rawlog, sk, pk, peerAddrs, *multicast, *mcastregexp)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/transport/yggdrasil.go
+++ b/internal/transport/yggdrasil.go
@@ -50,7 +50,7 @@ type yggdrasilDial struct {
 	context.CancelFunc
 }
 
-func NewYggdrasilTransport(log *log.Logger, sk ed25519.PrivateKey, pk ed25519.PublicKey, peers []string, mcast bool) (*YggdrasilTransport, error) {
+func NewYggdrasilTransport(log *log.Logger, sk ed25519.PrivateKey, pk ed25519.PublicKey, peers []string, mcast bool, mcastregexp string) (*YggdrasilTransport, error) {
 	yellow := color.New(color.FgYellow).SprintfFunc()
 	glog := gologme.New(log.Writer(), fmt.Sprintf("[ %s ] ", yellow("Yggdrasil")), gologme.LstdFlags|gologme.Lmsgprefix)
 	glog.EnableLevel("warn")
@@ -86,7 +86,7 @@ func NewYggdrasilTransport(log *log.Logger, sk ed25519.PrivateKey, pk ed25519.Pu
 	{
 		options := []multicast.SetupOption{
 			multicast.MulticastInterface{
-				Regex:  regexp.MustCompile(".*"),
+				Regex:  regexp.MustCompile(mcastregexp),
 				Beacon: mcast,
 				Listen: mcast,
 			},


### PR DESCRIPTION
The `mcastregexp` parameter has been added to allow the selection of a multicast interface.